### PR TITLE
Allow to read kdeglobals configuration

### DIFF
--- a/org.kde.kdenlive.yaml
+++ b/org.kde.kdenlive.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --filesystem=host
+  - --filesystem=xdg-config/kdeglobals:ro
   - --env=FREI0R_PATH=/app/lib/frei0r-1
   - --env=LADSPA_PATH=/app/lib/ladspa
 cleanup:


### PR DESCRIPTION
I know that now the application has access to the full home directory, but I think this should change in future and access to kdeglobals should remain, at least until we have a better way how to access configuration.