### PR TITLE
Use unified extension

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -17,10 +17,18 @@
     "--env=TMPDIR=/var/tmp",
     "--env=QT_ENABLE_HIGHDPI_SCALING=1",
     "--env=FREI0R_PATH=/app/lib/frei0r-1",
-    "--env=LADSPA_PATH=/app/extensions/LadspaPlugins/ladspa:/app/lib/ladspa",
+    "--env=LADSPA_PATH=/app/extensions/Plugins/ladspa:/app/extensions/LadspaPlugins/ladspa:/app/lib/ladspa",
     "--env=XDG_CURRENT_DESKTOP=kde"
   ],
   "add-extensions": {
+    "org.freedesktop.LinuxAudio.Plugins": {
+      "directory": "extensions/Plugins",
+      "version": "19.08",
+      "add-ld-path": "lib",
+      "merge-dirs": "ladspa",
+      "subdirectories": true,
+      "no-autodownload": true
+    },
     "org.freedesktop.LinuxAudio.LadspaPlugins": {
       "directory": "extensions/LadspaPlugins",
       "version": "19.08",
@@ -34,6 +42,7 @@
       "version": "19.08",
       "add-ld-path": "lib",
       "merge-dirs": "ladspa",
+      "autodelete": false,
       "subdirectories": true
     }
   },
@@ -437,6 +446,7 @@
         "-DCMAKE_BUILD_TYPE=Release"
       ],
       "post-install": [
+        "install -d /app/extensions/Plugins",
         "install -d /app/extensions/LadspaPlugins"
       ],
       "sources": [


### PR DESCRIPTION
There is now a unified extension point for linux audio plugins.

I added it. This doesn't change anything yet, it time the old extension point will be removed.
There is no extension using the new scheme yet, except locally here.