### PR TITLE
Update version in appdata

### DIFF
--- a/appdata-version.patch
+++ b/appdata-version.patch
@@ -1,0 +1,10 @@
+--- kdenlive-20.04.2/data/org.kde.kdenlive.appdata.xml	2020-06-09 17:22:41.000000000 -0400
++++ kdenlive-20.04.2/data/org.kde.kdenlive.appdata.xml-new	2020-07-06 19:15:55.156144232 -0400
+@@ -267,6 +267,7 @@
+     </ul>
+   </description>
+   <releases>
++    <release date="2020-06-09" version="20.04.2"/>
+     <release date="2020-05-11" version="20.04.1"/>
+   </releases>
+   <url type="homepage">https://kdenlive.org/</url>

--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -454,6 +454,10 @@
           "type": "archive",
           "url": "https://download.kde.org/stable/release-service/20.04.2/src/kdenlive-20.04.2.tar.xz",
           "sha256": "17539ba44397aeff19cda6c767741212f3e7e4ecb852b3d35787c1aca3d53ca6"
+        },
+        {
+          "type": "patch",
+          "path": "appdata-version.patch"
         }
       ]
     }


### PR DESCRIPTION
This dashboard indicated that kdenlive was behind on Flatpak:

https://fortwire.github.io/Who-Updates/

Because the appdata isn't up to date. So here we go.

I'll submit the patch upstream.