### PR TITLE
Revert "Update to latest movit version"

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -203,8 +203,8 @@
       "sources": [
         {
           "type": "git",
-          "url": "http://git.sesse.net/movit",
-          "commit": "f0c77209245aa206996c7ef5395888e2859ff4bf"
+          "url": "https://github.com/ddennedy/movit.git",
+          "commit": "3e8b4ebb796bcbe7e9727a2d7f2d0ba8f0170dfa"
         }
       ]
     },


### PR DESCRIPTION
Reverts flathub/org.kde.kdenlive#104

Can we please revert this until further notice? Please see: https://github.com/flathub/org.kde.kdenlive/pull/104#issuecomment-817182460