### PR TITLE
mlt: build with cmake, use v6 branch

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -609,7 +609,8 @@
         {
           "type": "git",
           "url": "https://github.com/mltframework/mlt.git",
-          "branch": "v6"
+          "branch": "v6",
+          "commit": "7063e88e09977282470c4f2f93e56e05f21b7c2b"
         }
       ]
     },

--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -599,18 +599,17 @@
     },
     {
       "name": "mlt",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
       "config-opts": [
-        "--enable-gpl",
-        "--enable-gpl3",
-        "--enable-opencv",
-        "--enable-opengl"
+        "-DMOD_OPENCV=ON",
+        "-DMOD_MOVIT=ON"
       ],
       "sources": [
         {
           "type": "git",
           "url": "https://github.com/mltframework/mlt.git",
-          "commit": "531aa1a19df55cc378c9c79b86c7cbb187487f37",
-          "tag": "v6.26.1"
+          "branch": "v6"
         }
       ]
     },


### PR DESCRIPTION
As you can read in this comment https://github.com/mltframework/mlt/issues/655#issuecomment-814504510 mlt is switching to cmake and will drop support for `configure` soon.

Further more we should use the `v6`. This branch is stable and does not receive new features, but bug fixes.