### PR TITLE
Fix the builder

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -575,7 +575,7 @@
       ]
     },
     {
-      "name": "aom",
+      "name": "libaom",
       "buildsystem": "cmake-ninja",
       "builddir": true,
       "config-opts": [

--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -591,7 +591,7 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://aomedia.googlesource.com/aom.git",
+          "url": "https://aomedia.googlesource.com/aom",
           "commit": "d853caa2ab62d161e5edf344ffee7b597449dc0d",
           "tag": "v3.0.0"
         }


### PR DESCRIPTION
The builder fails currently at download time at `aom` due to permission problems.

The hope is to fix this by renaming `aom` to `libaom`. If this doesn't work we should remove `aom` (temporarily) until we find a solution…