### PR TITLE
Update MLT to fix alpha channel regression

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -650,7 +650,7 @@
         {
           "type": "git",
           "url": "https://github.com/mltframework/mlt.git",
-          "commit": "685698ab01fea2ac5322ab074b3e827ead5a6739"
+          "commit": "4326547617645e5efe5c7d12b67ad8d9f3768525"
         }
       ]
     },


### PR DESCRIPTION
More info: https://github.com/mltframework/mlt/commit/4326547617645e5efe5c7d12b67ad8d9f3768525