### PR TITLE
Fix dbus errors

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -15,6 +15,7 @@
     "--socket=pulseaudio",
     "--share=network",
     "--filesystem=host",
+    "--system-talk-name=org.freedesktop.UDisks2",
     "--env=TMPDIR=/var/tmp",
     "--env=QT_ENABLE_HIGHDPI_SCALING=1",
     "--env=FREI0R_PATH=/app/lib/frei0r-1",


### PR DESCRIPTION
This fixes the following console errors:

```
kf.solid.backends.udisks2: Failed enumerating UDisks2 objects: "org.freedesktop.DBus.Error.Disconnected" 
 "Not connected to D-Bus server"
```