### PR TITLE
Downgrade nv-codec-headers and pin to version n11.x

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -526,14 +526,16 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/FFmpeg/nv-codec-headers/archive/refs/tags/n12.0.16.0.tar.gz",
-                    "sha256": "2a1533b65f55f9da52956faf0627ed3b74868ac0c7f269990edd21369113b48f",
+                    "type": "git",
+                    "url": "https://github.com/FFmpeg/nv-codec-headers.git",
+                    "tag": "n11.1.5.2",
+                    "commit": "f8ae7a49bfef2f99d2c931a791dc3863fda67bf3",
                     "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 223796,
-                        "stable-only": true,
-                        "url-template": "https://github.com/FFmpeg/nv-codec-headers/archive/refs/tags/n$version.tar.gz"
+                        "type": "git",
+                        "tag-pattern": "^n([\\d.]+)$",
+                        "versions": {
+                            "<": "12"
+                        }
                     }
                 }
             ]


### PR DESCRIPTION
This allows hardware accelerated rendering on older - yet still supported - generations of NVIDIA GPUs (such as Kepler).

![Screenshot_20230823_074925](https://github.com/flathub/org.kde.kdenlive/assets/626206/ea4bb7ab-9d6e-414b-ae52-eafa6dfc0314)

However, I'm not sure if this will negatively impact rendering on new NVIDIA GPUs, so if someone reading this has one, please give your feedback.

Thanks!