### PR TITLE
Upgrade KDE Runtime, LLVM and plugins 

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -572,7 +572,7 @@
             ]
         },
         {
-            "name": "mediasdk",
+            "name": "intel-onevpl-runtime",
             "skip-arches": [
                 "aarch64"
             ],
@@ -582,21 +582,40 @@
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DBUILD_SAMPLES=OFF",
                 "-DBUILD_TESTS=OFF",
-                "-DBUILD_TOOLS=OFF",
-                "-DBUILD_TESTS=OFF",
-                "-DMFX_ENABLE_SW_FALLBACK=OFF"
+                "-DBUILD_TOOLS=OFF"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/Intel-Media-SDK/MediaSDK/archive/intel-mediasdk-23.2.2.tar.gz",
-                    "sha256": "12f23a78104edc1c9bfa755effd2723866d107ad752f72d3839fcc8db0503cec",
+                    "url": "https://github.com/oneapi-src/oneVPL-intel-gpu/archive/intel-onevpl-23.3.4.tar.gz",
+                    "sha256": "9de6bfd17259b7434f2bb4fb6d2874decf9b1d4587ec9b90d91188049921e32f",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 21814,
                         "stable-only": true,
-                        "url-template": "https://github.com/Intel-Media-SDK/MediaSDK/archive/intel-mediasdk-$version.tar.gz"
+                        "url-template": "https://github.com/oneapi-src/oneVPL-intel-gpu/archive/intel-onevpl-$version.tar.gz"
                     }
+                }
+            ]
+        },
+        {
+            "name": "oneapi-libvpl",
+            "skip-arches": [
+                "aarch64"
+            ],
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DBUILD_SAMPLES=OFF",
+                "-DBUILD_TESTS=OFF",
+                "-DBUILD_TOOLS=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/oneapi-src/oneVPL/archive/refs/tags/v2023.3.1.zip",
+                    "sha256": "ea8d4ae355f14b0f40a8dfb1035ed1ebc2a4827e5447845d9a97d4bd466812bc"
                 }
             ]
         },
@@ -672,7 +691,7 @@
                 "arch": {
                     "x86_64": {
                         "config-opts": [
-                            "--enable-libmfx"
+                            "--enable-libvpl"
                         ]
                     }
                 }

--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -2,10 +2,10 @@
     "app-id": "org.kde.kdenlive",
     "default-branch": "stable",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-22.08",
+    "runtime-version": "5.15-23.08",
     "sdk": "org.kde.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.llvm15"
+        "org.freedesktop.Sdk.Extension.llvm17"
     ],
     "command": "kdenlive",
     "rename-icon": "kdenlive",
@@ -30,7 +30,7 @@
     "add-extensions": {
         "org.freedesktop.LinuxAudio.Plugins": {
             "directory": "extensions/Plugins",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": "lib",
             "merge-dirs": "ladspa",
             "subdirectories": true,
@@ -38,7 +38,7 @@
         },
         "org.freedesktop.LinuxAudio.Plugins.swh": {
             "directory": "extensions/Plugins/swh",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": "lib",
             "merge-dirs": "ladspa",
             "autodelete": false,
@@ -46,7 +46,7 @@
         },
         "org.freedesktop.LinuxAudio.Plugins.TAP": {
             "directory": "extensions/Plugins/TAP",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": "lib",
             "merge-dirs": "ladspa",
             "autodelete": false,
@@ -667,8 +667,8 @@
                 "--enable-vdpau"
             ],
             "build-options": {
-                "prepend-path": "/usr/lib/sdk/llvm15/bin",
-                "prepend-ld-library-path": "/usr/lib/sdk/llvm15/lib",
+                "prepend-path": "/usr/lib/sdk/llvm17/bin",
+                "prepend-ld-library-path": "/usr/lib/sdk/llvm17/lib",
                 "arch": {
                     "x86_64": {
                         "config-opts": [

--- a/patches/0001-Support-compiling-with-GCC-13-1605.patch
+++ b/patches/0001-Support-compiling-with-GCC-13-1605.patch
@@ -1,0 +1,26 @@
+From a0e9ddb8a51ef2778697e7b549713a2172a1a1a3 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Morin
+ <38703886+JeanChristopheMorinPerso@users.noreply.github.com>
+Date: Sat, 20 May 2023 14:52:46 -0400
+Subject: [PATCH] Support compiling with GCC 13 (#1605)
+
+Signed-off-by: Jean-Christophe Morin <jean_christophe_morin@hotmail.com>
+---
+ src/opentime/rationalTime.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/opentime/rationalTime.h b/src/opentime/rationalTime.h
+index ec791bc..fbdd02d 100644
+--- a/src/opentime/rationalTime.h
++++ b/src/opentime/rationalTime.h
+@@ -7,6 +7,7 @@
+ #include "opentime/version.h"
+ #include <cmath>
+ #include <limits>
++#include <cstdint>
+ #include <string>
+ 
+ namespace opentime { namespace OPENTIME_VERSION {
+-- 
+2.43.0
+

--- a/python-modules.json
+++ b/python-modules.json
@@ -35,6 +35,10 @@
                         "type": "pypi",
                         "name": "OpenTimelineIO"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/0001-Support-compiling-with-GCC-13-1605.patch"
                 }
             ]
         },


### PR DESCRIPTION
Update KDE platform to 5.15-23.08.
Update LLVM to LLVM17.
Update Linux Audio Plugins to 23.08.
Replace dropped and legacy Intel Media SDK for use the new Intel OneAPI's OneVPL Runtime.
About QSV idk if this is included in --non-free options, but if this is included is impossible for use this.

