### PR TITLE
Only build intel-onevpl-runtime on x86_64

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -573,8 +573,8 @@
         },
         {
             "name": "intel-onevpl-runtime",
-            "skip-arches": [
-                "aarch64"
+            "only-arches": [
+                "x86_64"
             ],
             "buildsystem": "cmake-ninja",
             "builddir": true,


### PR DESCRIPTION
See: https://github.com/flathub/org.kde.kdenlive/pull/292#discussion_r1432971138