### PR TITLE
finish-args: Only use X11 for now

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -12,8 +12,7 @@
     "finish-args": [
         "--require-version=0.11.4",
         "--share=ipc",
-        "--socket=fallback-x11",
-        "--socket=wayland",
+        "--socket=x11",
         "--device=all",
         "--socket=pulseaudio",
         "--share=network",


### PR DESCRIPTION
finish-args: Only use X11 for now

See: https://github.com/flathub/org.kde.kdenlive/issues/335