### PR TITLE
Fix duplicate and conflicting mlt cmake options

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -851,11 +851,8 @@
             "builddir": true,
             "config-opts": [
                 "-DMOD_GLAXNIMATE=OFF",
-                "-DMOD_GLAXNIMATE=ON",
                 "-DMOD_GLAXNIMATE_QT6=ON",
                 "-DMOD_MOVIT=ON",
-                "-DMOD_MOVIT=ON",
-                "-DMOD_OPENCV=ON",
                 "-DMOD_OPENCV=ON",
                 "-DMOD_QT6=ON",
                 "-DMOD_QT=OFF"


### PR DESCRIPTION
This fixes some duplicate options which were accidentally introduced in bbfd7c37e053a52c9110123466ca2c3bee28be74.

`-DMOD_GLAXNIMATE=OFF` seems to have been intentionally introduced by the above commit, so `-DMOD_GLAXNIMATE=ON` has been removed.