### PR TITLE
Dependency updates

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -559,12 +559,12 @@
                 {
                     "type": "git",
                     "url": "https://aomedia.googlesource.com/aom.git",
-                    "tag": "v3.9.1",
+                    "tag": "v3.10.0",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
                     },
-                    "commit": "8ad484f8a18ed1853c094e7d3a4e023b2a92df28"
+                    "commit": "c2fe6bf370f7c14fbaf12884b76244a3cfd7c5fc"
                 }
             ]
         },

--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -699,8 +699,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.ffmpeg.org/releases/ffmpeg-7.0.1.tar.xz",
-                    "sha256": "bce9eeb0f17ef8982390b1f37711a61b4290dc8c2a0c1a37b5857e85bfb0e4ff",
+                    "url": "https://www.ffmpeg.org/releases/ffmpeg-7.0.2.tar.xz",
+                    "sha256": "8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 5405,

--- a/python-modules.json
+++ b/python-modules.json
@@ -135,8 +135,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/1c/d5/c84e1a17bf61d4df64ca866a1c9a913874b4e9bdc131ec689a0ad013fb36/certifi-2024.7.4-py3-none-any.whl",
-                    "sha256": "c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90",
+                    "url": "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl",
+                    "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "certifi",

--- a/python-modules.json
+++ b/python-modules.json
@@ -117,8 +117,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/0f/b0/e53bdd53d86447d211694f3cf66f163d077c5d68e6bcaa726bf64e88ae3a/websockets-13.0.tar.gz",
-                    "sha256": "b7bf950234a482b7461afdb2ec99eee3548ec4d53f418c7990bb79c620476602",
+                    "url": "https://files.pythonhosted.org/packages/8f/1c/78687e0267b09412409ac134f10fd14d14ac6475da892a8b09a02d0f6ae2/websockets-13.0.1.tar.gz",
+                    "sha256": "4d6ece65099411cfd9a48d13701d7438d9c34f479046b34c50ff60bb8834e43e",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "websockets"


### PR DESCRIPTION
Exclude the "intel-onevpl-runtime: Update intel-onevpl-24.2.5.tar.gz to 24.3.1" update which fails to build.