### PR TITLE
Update python3-cffi, python3-requests and kdenlive

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -877,8 +877,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/24.08.0/src/kdenlive-24.08.0.tar.xz",
-                    "sha256": "e4306a2aa5a7535cea50aeff493ea9de8b7292d499d7204c41780cb044752f96",
+                    "url": "https://download.kde.org/stable/release-service/24.08.1/src/kdenlive-24.08.1.tar.xz",
+                    "sha256": "55b42af545304ec26bf20b4e9e79e89e91d61481fbbb93a5df7c74e86fbae142",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,

--- a/python-modules.json
+++ b/python-modules.json
@@ -89,8 +89,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/1e/bf/82c351342972702867359cfeba5693927efe0a8dd568165490144f554b18/cffi-1.17.0.tar.gz",
-                    "sha256": "f3157624b7558b914cb039fd1af735e5e8049a87c817cc215109ad1c8779df76",
+                    "url": "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz",
+                    "sha256": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "cffi"
@@ -174,8 +174,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/ca/1c/89ffc63a9605b583d5df2be791a27bc1a42b7c32bab68d3c8f2f73a98cd4/urllib3-2.2.2-py3-none-any.whl",
-                    "sha256": "a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+                    "url": "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl",
+                    "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "urllib3",


### PR DESCRIPTION
python3-cffi: Update cffi-1.17.0.tar.gz to 1.17.1
python3-requests: Update urllib3-2.2.2-py3-none-any.whl to 2.2.3
kdenlive: Update kdenlive-24.08.0.tar.xz to 24.08.1