### PR TITLE
Update python3-websockets, python3-requests and 4 more modules

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -581,7 +581,7 @@
                 "-DBUILD_TESTS=OFF",
                 "-DBUILD_TOOLS=OFF"
             ],
-           "sources": [
+            "sources": [
                 {
                     "type": "archive",
                     "url": "https://github.com/oneapi-src/oneVPL-intel-gpu/archive/intel-onevpl-24.2.5.tar.gz",
@@ -877,8 +877,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/24.08.1/src/kdenlive-24.08.1.tar.xz",
-                    "sha256": "55b42af545304ec26bf20b4e9e79e89e91d61481fbbb93a5df7c74e86fbae142",
+                    "url": "https://download.kde.org/stable/release-service/24.08.2/src/kdenlive-24.08.2.tar.xz",
+                    "sha256": "1556689ee92e769735b591bbf67b418671810feeed09ea565e9c8a00bdbf8fb7",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,

--- a/python-modules.json
+++ b/python-modules.json
@@ -117,8 +117,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/8f/1c/78687e0267b09412409ac134f10fd14d14ac6475da892a8b09a02d0f6ae2/websockets-13.0.1.tar.gz",
-                    "sha256": "4d6ece65099411cfd9a48d13701d7438d9c34f479046b34c50ff60bb8834e43e",
+                    "url": "https://files.pythonhosted.org/packages/e2/73/9223dbc7be3dcaf2a7bbf756c351ec8da04b1fa573edaf545b95f6b0c7fd/websockets-13.1.tar.gz",
+                    "sha256": "a3b3366087c1bc0a2795111edcadddb8b3b59509d5db5d7ea3fdd69f954a8878",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "websockets"
@@ -145,8 +145,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
-                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+                    "url": "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz",
+                    "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "charset-normalizer"
@@ -154,8 +154,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/22/7e/d71db821f177828df9dea8c42ac46473366f191be53080e552e628aad991/idna-3.8-py3-none-any.whl",
-                    "sha256": "050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
+                    "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
+                    "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "idna",


### PR DESCRIPTION
python3-websockets: Update websockets-13.0.1.tar.gz to 13.1
python3-requests: Update charset-normalizer-3.3.2.tar.gz to 3.4.0
python3-requests: Update idna-3.8-py3-none-any.whl to 3.10
amf-headers: Update v1.4.34.tar.gz to 1.4.35
ffmpeg: Update ffmpeg-7.0.2.tar.xz to 7.1
kdenlive: Update kdenlive-24.08.1.tar.xz to 24.08.2