### PR TITLE
Update Kdenlive and MLT

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -775,7 +775,7 @@
                     "type": "git",
                     "url": "https://github.com/mltframework/mlt.git",
                     "tag": "v7.30.0",
-                    "commit": "d6eaddcf916b1f7f560ea3325ca407acf52770b4"
+                    "commit": "b7bc13a618025795eb69c59ea315a410d33fb223"
                 }
             ]
         },
@@ -794,8 +794,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/24.12.1/src/kdenlive-24.12.1.tar.xz",
-                    "sha256": "6d1345462a1ad9a725dbf9ab42b8b340eeafc8437d9c0f52ac5ebacfdfd9b8b2",
+                    "url": "https://download.kde.org/stable/release-service/24.12.2/src/kdenlive-24.12.2.tar.xz",
+                    "sha256": "37be18de3583fda33fb246f312f5a4e25c1e64ae6d746668244252e2033ef489",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,

--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -774,7 +774,6 @@
                 {
                     "type": "git",
                     "url": "https://github.com/mltframework/mlt.git",
-                    "tag": "v7.30.0",
                     "commit": "b7bc13a618025795eb69c59ea315a410d33fb223"
                 }
             ]


### PR DESCRIPTION
Update Kdenlive to latest version. update MLT to fix important issues with rotoscoping and qtblend.