### PR TITLE
Build sox from git

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -172,9 +172,9 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://sourceforge.net/code-snapshots/git/s/so/sox/code.git/sox-code-f3094754a7c2a7e55c35621d20fa9945736e72df.zip",
-                    "sha256": "ab0820a7dfe40a6ca2da6086d4df66ecfbdd5d7f84bca97c44b96936aa192f85"
+                    "type": "git",
+                    "url": "https://git.code.sf.net/p/sox/code",
+                    "commit": "f3094754a7c2a7e55c35621d20fa9945736e72df"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
There are problems with sf connectivity when using archives.