### PR TITLE
Aktualisieren von org.kde.kdenlive.json

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -24,7 +24,6 @@
         "--env=QT_ENABLE_HIGHDPI_SCALING=1",
         "--env=FREI0R_PATH=/app/lib/frei0r-1",
         "--env=LADSPA_PATH=/app/extensions/Plugins/ladspa:/app/lib/ladspa",
-        "--env=XDG_CURRENT_DESKTOP=kde",
         "--env=PACKAGE_TYPE=flatpak"
     ],
     "add-extensions": {


### PR DESCRIPTION
Remove XDG_CURRENT_DESKTOP=kde

This has been added several years ago to fix a theming issue. See #53

Nowadays it should not be needed anymore and causes bugs like https://bugs.kde.org/show_bug.cgi?id=463047