### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -58,9 +58,11 @@
         "/lib/cmake",
         "/mkspecs",
         "/share/aclocal",
+        "/share/doc",
         "/share/gtk-doc",
         "/share/man",
         "/share/pkgconfig",
+        "/share/qlogging-categories6",
         "*.a",
         "*.la",
         "*.cmake"


### PR DESCRIPTION
### Drop /share/doc folder

KDE apps usually open an external website for help documentation.

This app uses the following page: https://docs.kdenlive.org/en/

### Drop /share/qlogging-categories folder

Many projects drop this folder

See: https://github.com/search?q=org%3Aflathub+%2Fshare%2Fqlogging-categories&type=code