### PR TITLE
Update MLT with latest qtblend fixes

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -707,7 +707,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/mltframework/mlt.git",
-                    "commit": "42487f227fbad0fc90ad99063ba8e99434786ca3"
+                    "commit": "f55c53e88eb7f7f58ebd982de818b33962167009"
                 }
             ]
         },


### PR DESCRIPTION
Several fixes for quality or possible crash were committed in the last days in MLT in anticipation of the upcoming release.
It would be nice to have them in 26.04. See for example :

- [Fix poor quality scaling](https://github.com/mltframework/mlt/commit/fe9ab9104beeef87c13f9e80ca1914276e0d4d1a)
- Ensure we don't request huge images causing freezes[1](https://github.com/mltframework/mlt/commit/d3463fadbb564112e8403e70568b3c2a32be1089) and [2](https://github.com/mltframework/mlt/commit/f55c53e88eb7f7f58ebd982de818b33962167009)

