### PR TITLE
Fix MLT linking to incorrect FFmpeg

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -702,7 +702,8 @@
                 "-DMOD_OPENCV=ON",
                 "-DMOD_QT6=ON",
                 "-DMOD_QT=OFF",
-                "-DUSE_VST2=OFF"
+                "-DUSE_VST2=OFF",
+                "-DCMAKE_PREFIX_PATH=/app"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Ensure MLT finds the correct FFmpeg version, allows upgrading to FFmpeg 8.x