### PR TITLE
Downgrade FFmpeg to 8.0.x until metadata rotation regression is fixed…

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -586,8 +586,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.ffmpeg.org/releases/ffmpeg-8.1.1.tar.xz",
-                    "sha256": "b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3",
+                    "url": "https://www.ffmpeg.org/releases/ffmpeg-8.0.2.tar.xz",
+                    "sha256": "5d16962332603c427b3d0887fc12b9166d6ee2cb1108b1865dd2d5eb06a09505",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 5405,


### PR DESCRIPTION
FFmpeg 8.1.x has a regression breaking transcoding of files with rotation metadata:
https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/23383